### PR TITLE
Fixes segfault due to use of erase() inside range-based for loop

### DIFF
--- a/static/schedgen/parallel/LoopSelect.cpp
+++ b/static/schedgen/parallel/LoopSelect.cpp
@@ -267,8 +267,8 @@ filterLoopHeuristicBased(JanusContext *jc, std::set<LoopID> &selected)
         }*/
     }
 
-    for (auto id: toRemove)
-        selected.erase(id);
+    for (auto id_it = toRemove.begin(); id_it != toRemove.end(); )
+        id_it = selected.erase(id_it);
 }
 
 static bool
@@ -344,8 +344,8 @@ rejectLoopFromRuntimeFeedback(JanusContext *jc, std::set<LoopID> &selected)
         }
     }
 
-    for (auto id: toRemove) {
-        selected.erase(id);
+    for (auto id_it = toRemove.begin(); id_it != toRemove.end(); ) {
+        id_it = selected.erase(id_it);
     }
 }
 
@@ -368,9 +368,11 @@ selectLoopFromRuntimeFeedback(JanusContext *jc, std::set<LoopID> &selected)
     LOOPLOG(endl);
 
     //remove unsafe loops
-    for (auto lid: selected) {
-        if (jc->loops[lid-1].unsafe)
-            selected.erase(lid);
+    for (auto lid_it = selected.begin(); lid_it != selected.end(); ) {
+        if (jc->loops[*lid_it-1].unsafe)
+            lid_it = selected.erase(lid_it);
+        else
+            lid_it++;
     }
     return true;
 }


### PR DESCRIPTION
Hello! Firstly, I want to put it out there that Janus is an amazing project.

This pull request aims to fix a segmentation fault error I was getting when executing tests. In C++11, it is invalid to erase an element of a container while using a range-based for loop for iteration (Referring from [this](https://stackoverflow.com/questions/10360461/removing-item-from-vector-while-in-c11-range-for-loop) SO answer).

Thanks,
Chinmay