### PR TITLE
Patch to check for and handle array out of bound in post dominator

### DIFF
--- a/static/analysis/ControlFlow.cpp
+++ b/static/analysis/ControlFlow.cpp
@@ -541,8 +541,10 @@ buildPostDominanceTree(Function &function)
             /* If the number of pdominators of BB d is 1 less than the pdominators of BB i,
              * Then it means the immediate post dominator of i is d */
             if (pdomTree[d].size() + 1 == pdominators.size()) {
-                bb.ipdom = &function.entry[d];
-                break;
+            	if (d < function.numBlocks) {
+                    bb.ipdom = &function.entry[d];
+                    break;
+                }
             }
         }
         pdominators.clear();


### PR DESCRIPTION
This is a simple patch for issue https://github.com/CompArchCam/Janus/issues/3. Wraps the statement with potential array out of bound errors with an explicit array bound check.